### PR TITLE
perf(device-detail): avoid memory leak when closing the dialog or filtering icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "homey-panel",
   "version": "0.1.1",
   "scripts": {
-    "build": "ng build",
+    "build": "ng build --prod=true",
     "e2e": "ng e2e",
     "eslint": "eslint src e2e --ext .ts --fix",
     "generate-icon-json": "cat src/assets/icons.svg | awk -F\"id=\" '{print $2}' | cut -f1 -d' ' | grep . | awk ' BEGIN { ORS = \"\"; print \"{ \\\"icons\\\": [\"; } { print $0\",\"; } END { print \"] }\"; }' | sed \"s/,]/]/\" > src/assets/icons.json",

--- a/src/app/components/device-detail/device-detail.component.ts
+++ b/src/app/components/device-detail/device-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, OnDestroy } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DragulaService } from 'ng2-dragula';
 import { PanelDevice, PanelSettings } from '../../services/core.service';
@@ -14,13 +14,14 @@ export interface DeviceDetailData {
   templateUrl: './device-detail.component.html',
   styleUrls: ['./device-detail.component.scss']
 })
-export class DeviceDetailComponent {
+export class DeviceDetailComponent implements OnDestroy {
 
   settings: PanelSettings;
   icons: string[];
   availableCapabilities: string[];
   iconFilter: string;
   filtering;
+  throttling;
 
   constructor(
     public dialogRef: MatDialogRef<DeviceDetailComponent>,
@@ -38,7 +39,7 @@ export class DeviceDetailComponent {
     });
   }
 
-  acceptMoreCapabilities(el, target): boolean {
+  acceptMoreCapabilities(el?, target?): boolean {
     return target && target.id !== 'selectedCapabilities' || this.settings.info.length < 3;
   }
 
@@ -59,9 +60,10 @@ export class DeviceDetailComponent {
   }
 
   throttle(array, items, index = 0): void {
+    if (this.throttling) clearTimeout(this.throttling);
     if (!items[index]) return;
     array.push(items[index]);
-    setTimeout(() => {
+    this.throttling = setTimeout(() => {
       this.throttle(array, items, index + 1);
     });
   }
@@ -79,6 +81,11 @@ export class DeviceDetailComponent {
       to.push(from[index]);
       from.splice(index, 1);
     }
+  }
+
+  ngOnDestroy(): void {
+    if (this.filtering) clearTimeout(this.filtering);
+    if (this.throttling) clearTimeout(this.throttling);
   }
 
 }

--- a/src/app/components/device-tile/long-press.directive.ts
+++ b/src/app/components/device-tile/long-press.directive.ts
@@ -67,13 +67,15 @@ export class LongPressDirective implements AfterContentChecked {
   @HostListener('mouseleave', ['$event'])
   @HostListener('mousemove', ['$event'])
   endPress(event): void {
-    clearTimeout(this.timeout);
-    clearInterval(this.interval);
-    if (this.pressing && !this.longPressing && event.type !== 'mousemove') {
-      this.onPress.emit(event);
+    if (this.swiping === NO_SWIPING) {
+      clearTimeout(this.timeout);
+      clearInterval(this.interval);
+      if (this.pressing && !this.longPressing && event.type !== 'mousemove') {
+        this.onPress.emit(event);
+      }
+      this.longPressing = false;
+      this.pressing = false;
     }
-    this.longPressing = false;
-    this.pressing = false;
   }
 
   constructor(private element: ElementRef) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "ES5",
     "resolveJsonModule": true,
     "typeRoots": [
       "node_modules/@types"
@@ -23,5 +23,9 @@
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true
-  }
+  },
+  "exclude": [
+    "src/assets/icon-set.svg",
+    "src/assets/design.sketch"
+   ]
 }


### PR DESCRIPTION
This closes Issue #11 where scheduled timers were not properly cleared on device detail destroy